### PR TITLE
making last matching rule take precedence

### DIFF
--- a/src/commands/__snapshots__/audit.test.int.ts.snap
+++ b/src/commands/__snapshots__/audit.test.int.ts.snap
@@ -7,12 +7,11 @@ exports[`audit csv should calculate stats when asked: stdout 1`] = `
 total,12,30
 loved,12,30
 unloved,0,0
-@global-owner1,12,30
-@global-owner2,12,30
-@js-owner,3,0
+@global-owner1,5,30
+@global-owner2,5,30
 @octocat,4,0
 @doctocat,2,0
-docs@example.com,1,0
+@js-owner,1,0
 "
 `;
 
@@ -23,9 +22,6 @@ exports[`audit csv should do all commands in combination when asked: stdout 1`] 
 total,2,0
 loved,2,0
 unloved,0,0
-@global-owner1,2,0
-@global-owner2,2,0
-@js-owner,1,0
 @octocat,2,0
 "
 `;
@@ -36,15 +32,15 @@ exports[`audit csv should list ownership for all files: stdout 1`] = `
 ".github/CODEOWNERS,@global-owner1,@global-owner2
 .gitignore,@global-owner1,@global-owner2
 README.md,@global-owner1,@global-owner2
-apps/some-file.js,@global-owner1,@global-owner2,@js-owner,@octocat
-apps/some-file.ts,@global-owner1,@global-owner2,@octocat
-build/logs/log.log,@global-owner1,@global-owner2,@doctocat
-deep/apps/some-file.js,@global-owner1,@global-owner2,@js-owner,@octocat
-deep/apps/some-file.ts,@global-owner1,@global-owner2,@octocat
+apps/some-file.js,@octocat
+apps/some-file.ts,@octocat
+build/logs/log.log,@doctocat
+deep/apps/some-file.js,@octocat
+deep/apps/some-file.ts,@octocat
 deep/build/logs/log.log,@global-owner1,@global-owner2
 deep/docs/SOMEDOC.md,@global-owner1,@global-owner2
-docs/SOMEDOC.md,@global-owner1,@global-owner2,docs@example.com,@doctocat
-src/index.js,@global-owner1,@global-owner2,@js-owner
+docs/SOMEDOC.md,@doctocat
+src/index.js,@js-owner
 "
 `;
 
@@ -55,22 +51,22 @@ exports[`audit csv should show only unloved files when asked: stdout 1`] = `""`;
 exports[`audit csv should use a specific root when asked: stderr 1`] = `""`;
 
 exports[`audit csv should use a specific root when asked: stdout 1`] = `
-"apps/some-file.js,@global-owner1,@global-owner2,@js-owner,@octocat
-apps/some-file.ts,@global-owner1,@global-owner2,@octocat
+"apps/some-file.js,@octocat
+apps/some-file.ts,@octocat
 "
 `;
 
 exports[`audit jsonl should calculate stats when asked: stderr 1`] = `""`;
 
 exports[`audit jsonl should calculate stats when asked: stdout 1`] = `
-"{\\"total\\":{\\"files\\":12,\\"lines\\":30},\\"unloved\\":{\\"files\\":0,\\"lines\\":0},\\"loved\\":{\\"files\\":12,\\"lines\\":30},\\"owners\\":[{\\"owner\\":\\"@global-owner1\\",\\"counters\\":{\\"files\\":12,\\"lines\\":30}},{\\"owner\\":\\"@global-owner2\\",\\"counters\\":{\\"files\\":12,\\"lines\\":30}},{\\"owner\\":\\"@js-owner\\",\\"counters\\":{\\"files\\":3,\\"lines\\":0}},{\\"owner\\":\\"@octocat\\",\\"counters\\":{\\"files\\":4,\\"lines\\":0}},{\\"owner\\":\\"@doctocat\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0}},{\\"owner\\":\\"docs@example.com\\",\\"counters\\":{\\"files\\":1,\\"lines\\":0}}]}
+"{\\"total\\":{\\"files\\":12,\\"lines\\":30},\\"unloved\\":{\\"files\\":0,\\"lines\\":0},\\"loved\\":{\\"files\\":12,\\"lines\\":30},\\"owners\\":[{\\"owner\\":\\"@global-owner1\\",\\"counters\\":{\\"files\\":5,\\"lines\\":30}},{\\"owner\\":\\"@global-owner2\\",\\"counters\\":{\\"files\\":5,\\"lines\\":30}},{\\"owner\\":\\"@octocat\\",\\"counters\\":{\\"files\\":4,\\"lines\\":0}},{\\"owner\\":\\"@doctocat\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0}},{\\"owner\\":\\"@js-owner\\",\\"counters\\":{\\"files\\":1,\\"lines\\":0}}]}
 "
 `;
 
 exports[`audit jsonl should do all commands in combination when asked: stderr 1`] = `""`;
 
 exports[`audit jsonl should do all commands in combination when asked: stdout 1`] = `
-"{\\"total\\":{\\"files\\":2,\\"lines\\":0},\\"unloved\\":{\\"files\\":0,\\"lines\\":0},\\"loved\\":{\\"files\\":2,\\"lines\\":0},\\"owners\\":[{\\"owner\\":\\"@global-owner1\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0}},{\\"owner\\":\\"@global-owner2\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0}},{\\"owner\\":\\"@js-owner\\",\\"counters\\":{\\"files\\":1,\\"lines\\":0}},{\\"owner\\":\\"@octocat\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0}}]}
+"{\\"total\\":{\\"files\\":2,\\"lines\\":0},\\"unloved\\":{\\"files\\":0,\\"lines\\":0},\\"loved\\":{\\"files\\":2,\\"lines\\":0},\\"owners\\":[{\\"owner\\":\\"@octocat\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0}}]}
 "
 `;
 
@@ -80,15 +76,15 @@ exports[`audit jsonl should list ownership for all files: stdout 1`] = `
 "{\\"path\\":\\".github/CODEOWNERS\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\"],\\"lines\\":30}
 {\\"path\\":\\".gitignore\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\"],\\"lines\\":0}
 {\\"path\\":\\"README.md\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\"],\\"lines\\":0}
-{\\"path\\":\\"apps/some-file.js\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"@js-owner\\",\\"@octocat\\"],\\"lines\\":0}
-{\\"path\\":\\"apps/some-file.ts\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"@octocat\\"],\\"lines\\":0}
-{\\"path\\":\\"build/logs/log.log\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"@doctocat\\"],\\"lines\\":0}
-{\\"path\\":\\"deep/apps/some-file.js\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"@js-owner\\",\\"@octocat\\"],\\"lines\\":0}
-{\\"path\\":\\"deep/apps/some-file.ts\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"@octocat\\"],\\"lines\\":0}
+{\\"path\\":\\"apps/some-file.js\\",\\"owners\\":[\\"@octocat\\"],\\"lines\\":0}
+{\\"path\\":\\"apps/some-file.ts\\",\\"owners\\":[\\"@octocat\\"],\\"lines\\":0}
+{\\"path\\":\\"build/logs/log.log\\",\\"owners\\":[\\"@doctocat\\"],\\"lines\\":0}
+{\\"path\\":\\"deep/apps/some-file.js\\",\\"owners\\":[\\"@octocat\\"],\\"lines\\":0}
+{\\"path\\":\\"deep/apps/some-file.ts\\",\\"owners\\":[\\"@octocat\\"],\\"lines\\":0}
 {\\"path\\":\\"deep/build/logs/log.log\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\"],\\"lines\\":0}
 {\\"path\\":\\"deep/docs/SOMEDOC.md\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\"],\\"lines\\":0}
-{\\"path\\":\\"docs/SOMEDOC.md\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"docs@example.com\\",\\"@doctocat\\"],\\"lines\\":0}
-{\\"path\\":\\"src/index.js\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"@js-owner\\"],\\"lines\\":0}
+{\\"path\\":\\"docs/SOMEDOC.md\\",\\"owners\\":[\\"@doctocat\\"],\\"lines\\":0}
+{\\"path\\":\\"src/index.js\\",\\"owners\\":[\\"@js-owner\\"],\\"lines\\":0}
 "
 `;
 
@@ -99,8 +95,8 @@ exports[`audit jsonl should show only unloved files when asked: stdout 1`] = `""
 exports[`audit jsonl should use a specific root when asked: stderr 1`] = `""`;
 
 exports[`audit jsonl should use a specific root when asked: stdout 1`] = `
-"{\\"path\\":\\"apps/some-file.js\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"@js-owner\\",\\"@octocat\\"],\\"lines\\":0}
-{\\"path\\":\\"apps/some-file.ts\\",\\"owners\\":[\\"@global-owner1\\",\\"@global-owner2\\",\\"@octocat\\"],\\"lines\\":0}
+"{\\"path\\":\\"apps/some-file.js\\",\\"owners\\":[\\"@octocat\\"],\\"lines\\":0}
+{\\"path\\":\\"apps/some-file.ts\\",\\"owners\\":[\\"@octocat\\"],\\"lines\\":0}
 "
 `;
 
@@ -113,12 +109,11 @@ Total: 12 files (30 lines)
 Loved: 12 files (30 lines)
 Unloved: 0 files (0 lines)
 --- Owners ---
-@global-owner1: 12 files (30 lines)
-@global-owner2: 12 files (30 lines)
-@js-owner: 3 files (0 lines)
+@global-owner1: 5 files (30 lines)
+@global-owner2: 5 files (30 lines)
 @octocat: 4 files (0 lines)
 @doctocat: 2 files (0 lines)
-docs@example.com: 1 files (0 lines)
+@js-owner: 1 files (0 lines)
 "
 `;
 
@@ -131,9 +126,6 @@ Total: 2 files (0 lines)
 Loved: 2 files (0 lines)
 Unloved: 0 files (0 lines)
 --- Owners ---
-@global-owner1: 2 files (0 lines)
-@global-owner2: 2 files (0 lines)
-@js-owner: 1 files (0 lines)
 @octocat: 2 files (0 lines)
 "
 `;
@@ -144,15 +136,15 @@ exports[`audit simple should list ownership for all files: stdout 1`] = `
 ".github/CODEOWNERS	@global-owner1	@global-owner2
 .gitignore	@global-owner1	@global-owner2
 README.md	@global-owner1	@global-owner2
-apps/some-file.js	@global-owner1	@global-owner2	@js-owner	@octocat
-apps/some-file.ts	@global-owner1	@global-owner2	@octocat
-build/logs/log.log	@global-owner1	@global-owner2	@doctocat
-deep/apps/some-file.js	@global-owner1	@global-owner2	@js-owner	@octocat
-deep/apps/some-file.ts	@global-owner1	@global-owner2	@octocat
+apps/some-file.js	@octocat
+apps/some-file.ts	@octocat
+build/logs/log.log	@doctocat
+deep/apps/some-file.js	@octocat
+deep/apps/some-file.ts	@octocat
 deep/build/logs/log.log	@global-owner1	@global-owner2
 deep/docs/SOMEDOC.md	@global-owner1	@global-owner2
-docs/SOMEDOC.md	@global-owner1	@global-owner2	docs@example.com	@doctocat
-src/index.js	@global-owner1	@global-owner2	@js-owner
+docs/SOMEDOC.md	@doctocat
+src/index.js	@js-owner
 "
 `;
 
@@ -163,7 +155,7 @@ exports[`audit simple should show only unloved files when asked: stdout 1`] = `"
 exports[`audit simple should use a specific root when asked: stderr 1`] = `""`;
 
 exports[`audit simple should use a specific root when asked: stdout 1`] = `
-"apps/some-file.js	@global-owner1	@global-owner2	@js-owner	@octocat
-apps/some-file.ts	@global-owner1	@global-owner2	@octocat
+"apps/some-file.js	@octocat
+apps/some-file.ts	@octocat
 "
 `;

--- a/src/lib/OwnershipEngine.test.ts
+++ b/src/lib/OwnershipEngine.test.ts
@@ -31,22 +31,23 @@ describe('OwnershipEngine', () => {
       expect(result).toEqual(expectedOwners);
     });
 
-    it('should (incorrectly) augment owners when there are multiple matching rules', () => {
-      // see https://github.com/jjmschofield/github-codeowners/issues/2
+    it('should should take precedence from the last matching rule', () => {
       // Arrange
-      const expectedOwners = ['@owner-1', '@owner-2'];
+      const expectedOwner = '@owner-2';
+      const unexpectedOwner = '@owner-1';
       const path = 'my/awesome/file.ts';
 
       const underTest = new OwnershipEngine([
-        createFileOwnershipMatcher(path, [expectedOwners[0]]),
-        createFileOwnershipMatcher(path, [expectedOwners[1]]),
+        createFileOwnershipMatcher(path, [unexpectedOwner]),
+        createFileOwnershipMatcher(path, [expectedOwner]),
       ]);
 
       // Act
       const result = underTest.calcFileOwnership(path);
 
       // Assert
-      expect(result).toEqual(expectedOwners);
+      expect(result).toContainEqual(expectedOwner);
+      expect(result).not.toContainEqual(unexpectedOwner);
     });
   });
 });

--- a/src/lib/OwnershipEngine.ts
+++ b/src/lib/OwnershipEngine.ts
@@ -6,24 +6,26 @@ import { log } from './logger';
 export class OwnershipEngine {
   private readonly matchers: FileOwnershipMatcher[];
 
+  /**
+   * @param matchers : FileOwnershipMatcher Matchers should be in precedence order, with overriding rules coming last
+   */
   constructor(matchers: FileOwnershipMatcher[]) {
     this.matchers = matchers;
   }
 
   public calcFileOwnership(filePath: string): string[] {
-    const owners: Set<string> = new Set();
+    let matching : FileOwnershipMatcher | null = null;
 
     // Enumerate all matching rules
     for (const matcher of this.matchers) {
       // Test to see if this matcher is a hit for the file path
       if (matcher.match(filePath)) {
-        // Add each of the owners to our owner set
-        matcher.owners.forEach(owner => owners.add(owner));
+        // Update the selected matcher to the matching rule, this will result in later rules taking precedence
+        matching = matcher;
       }
     }
 
-    // Fin
-    return Array.from(owners.values());
+    return matching ? matching.owners : [];
   }
 
   public static FromCodeownersFile(filePath: string) {

--- a/src/lib/OwnershipEngine.ts
+++ b/src/lib/OwnershipEngine.ts
@@ -14,18 +14,17 @@ export class OwnershipEngine {
   }
 
   public calcFileOwnership(filePath: string): string[] {
-    let matching : FileOwnershipMatcher | null = null;
+    // We reverse the matchers so that the first matching rule encountered
+    // will be the last from CODEOWNERS, respecting precedence correctly and performantly
+    const matchers = [...this.matchers].reverse();
 
-    // Enumerate all matching rules
-    for (const matcher of this.matchers) {
-      // Test to see if this matcher is a hit for the file path
+    for (const matcher of matchers) {
       if (matcher.match(filePath)) {
-        // Update the selected matcher to the matching rule, this will result in later rules taking precedence
-        matching = matcher;
+        return matcher.owners;
       }
     }
 
-    return matching ? matching.owners : [];
+    return [];
   }
 
   public static FromCodeownersFile(filePath: string) {


### PR DESCRIPTION
Previously owners from matching rules were concatenated together. This logic is incorrect based on https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax

The new logic will ensure that the last matching rule takes precedence. 