### PR TITLE
feat(who): accept multiple files

### DIFF
--- a/.idea/github-codeowners.iml
+++ b/.idea/github-codeowners.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/temp" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
     </content>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-codeowners",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,18 +60,18 @@ commander.command('validate')
   });
 
 
-commander.command('who <file>')
-  .description('lists owners of a specific file')
+commander.command('who <files...>')
+  .description('lists owners of a specific file or files')
   .option('-d, --dir <dirPath>', 'path to VCS directory', process.cwd())
   .option('-c, --codeowners <filePath>', 'path to codeowners file (default: "<dir>/.github/CODEOWNERS")')
   .option('-o, --output <outputFormat>', `how to output format eg: ${Object.values(OUTPUT_FORMAT).join(', ')}`, OUTPUT_FORMAT.SIMPLE)
-  .action(async (file, options) => {
+  .action(async (files, options) => {
     try {
-      if (!file) {
-        throw new Error('a file must be defined');
+      if (0 === files.length) {
+        throw new Error('a files must be defined');
       }
 
-      options.file = file;
+      options.files = files;
 
       if (!options.codeowners) {
         options.codeowners = path.resolve(options.dir, '.github/CODEOWNERS');

--- a/src/commands/__snapshots__/who.test.int.ts.snap
+++ b/src/commands/__snapshots__/who.test.int.ts.snap
@@ -1,8 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`who should list ownership for all files: stderr 1`] = `""`;
+exports[`who should list ownership for multiple files: stderr 1`] = `""`;
 
-exports[`who should list ownership for all files: stdout 1`] = `
+exports[`who should list ownership for multiple files: stdout 1`] = `
+"explicit-ignore.js	@js-owner
+default-wildcard-owners.md	@global-owner1	@global-owner2
+"
+`;
+
+exports[`who should list ownership for one file: stderr 1`] = `""`;
+
+exports[`who should list ownership for one file: stdout 1`] = `
 "default-wildcard-owners.md	@global-owner1	@global-owner2
 "
 `;

--- a/src/commands/who.test.int.ts
+++ b/src/commands/who.test.int.ts
@@ -21,8 +21,14 @@ describe('who', () => {
     return exec(`node  ../../../dist/cli.js ${args}`, { cwd: testDir });
   };
 
-  it('should list ownership for all files', async () => {
+  it('should list ownership for one file', async () => {
     const { stdout, stderr } = await runCli('who default-wildcard-owners.md');
+    expect(stdout).toMatchSnapshot('stdout');
+    expect(stderr).toMatchSnapshot('stderr');
+  });
+
+  it('should list ownership for multiple files', async () => {
+    const { stdout, stderr } = await runCli('who explicit-ignore.js default-wildcard-owners.md');
     expect(stdout).toMatchSnapshot('stdout');
     expect(stderr).toMatchSnapshot('stderr');
   });

--- a/src/commands/who.ts
+++ b/src/commands/who.ts
@@ -2,7 +2,7 @@ import { OwnershipEngine, OwnedFile } from '../lib/ownership';
 import { writeOwnedFile, OUTPUT_FORMAT } from '../lib/writers';
 
 interface WhoOptions {
-  file: string;
+  files: string[];
   dir: string;
   codeowners: string;
   output: OUTPUT_FORMAT;
@@ -10,6 +10,8 @@ interface WhoOptions {
 
 export const who = async (options: WhoOptions) => {
   const engine = OwnershipEngine.FromCodeownersFile(options.codeowners);
-  const file = await OwnedFile.FromPath(options.file, engine);
-  writeOwnedFile(file, options, process.stdout);
+  for (const file of options.files) {
+    const owned = await OwnedFile.FromPath(file, engine);
+    writeOwnedFile(owned, options, process.stdout);
+  }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,6 +76,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
   "exclude": [
+    "dist",
     "tests"
   ]
 }


### PR DESCRIPTION
Allow `github-codeowners who a.js b.js`, identical to `github-codeowners who a.js; github-codeowners who b.js` but more convenient.