### PR TITLE
fix: only count lines if required by output plugin

### DIFF
--- a/.idea/github-codeowners.iml
+++ b/.idea/github-codeowners.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/temp" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
     </content>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-codeowners",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/commands/__snapshots__/who.test.int.ts.snap
+++ b/src/commands/__snapshots__/who.test.int.ts.snap
@@ -6,3 +6,10 @@ exports[`who should list ownership for all files: stdout 1`] = `
 "default-wildcard-owners.md	@global-owner1	@global-owner2
 "
 `;
+
+exports[`who should not have read the file: stderr 1`] = `""`;
+
+exports[`who should not have read the file: stdout 1`] = `
+"does-not-exist.js	@js-owner
+"
+`;

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,6 +1,6 @@
 import { OUTPUT_FORMAT, writeOwnedFile, writeStats } from '../lib/writers';
 import { calcFileStats } from '../lib/stats';
-import { getFileOwnership } from '../lib/ownership';
+import { getFileOwnership, OwnedFile } from '../lib/ownership';
 
 interface AuditOptions {
   codeowners: string;
@@ -13,7 +13,10 @@ interface AuditOptions {
 }
 
 export const audit = async (options: AuditOptions) => {
-  const files = await getFileOwnership(options);
+  const fileOptions = OwnedFile.RecommendedOptions(options);
+  fileOptions.countLines = fileOptions.countLines || options.stats;
+
+  const files = await getFileOwnership(options, fileOptions);
 
   if (options.stats) {
     const stats = calcFileStats(files);

--- a/src/commands/who.test.int.ts
+++ b/src/commands/who.test.int.ts
@@ -39,7 +39,9 @@ describe('who', () => {
     expect(execMs).toBeLessThan(200);
   });
 
-  it('should error if the file is not present', async () => {
-    await expect(runCli('who does-not-exist.js')).rejects.toThrow('Command failed');
+  it('should not have read the file', async () => {
+    const { stdout, stderr } = await runCli('who does-not-exist.js');
+    expect(stdout).toMatchSnapshot('stdout');
+    expect(stderr).toMatchSnapshot('stderr');
   });
 });

--- a/src/commands/who.test.int.ts
+++ b/src/commands/who.test.int.ts
@@ -38,4 +38,8 @@ describe('who', () => {
 
     expect(execMs).toBeLessThan(200);
   });
+
+  it('should error if the file is not present', async () => {
+    await expect(runCli('who does-not-exist.js')).rejects.toThrow('Command failed');
+  });
 });

--- a/src/commands/who.ts
+++ b/src/commands/who.ts
@@ -10,6 +10,7 @@ interface WhoOptions {
 
 export const who = async (options: WhoOptions) => {
   const engine = OwnershipEngine.FromCodeownersFile(options.codeowners);
-  const file = await OwnedFile.FromPath(options.file, engine);
+  const fileOptions = OwnedFile.RecommendedOptions(options);
+  const file = await OwnedFile.FromPath(options.file, engine, fileOptions);
   writeOwnedFile(file, options, process.stdout);
 };

--- a/src/lib/ownership/file.ts
+++ b/src/lib/ownership/file.ts
@@ -1,10 +1,10 @@
 import * as path from 'path';
-import { OwnedFile } from './lib/OwnedFile';
+import { FromFileOptions, OwnedFile } from './lib/OwnedFile';
 import { OwnershipEngine } from './lib/OwnershipEngine';
 import { readDirRecursively } from './lib/readDirRecursively';
 import { readTrackedGitFiles } from './lib/readTrackedGitFiles';
 
-export const getFileOwnership = async (options: { codeowners: string, dir: string, onlyGit: boolean, root?: string }): Promise<OwnedFile[]> => {
+export const getFileOwnership = async (options: { codeowners: string, dir: string, onlyGit: boolean, root?: string }, fileOptions: FromFileOptions): Promise<OwnedFile[]> => {
   const engine = OwnershipEngine.FromCodeownersFile(options.codeowners);
 
   let filePaths;
@@ -23,7 +23,7 @@ export const getFileOwnership = async (options: { codeowners: string, dir: strin
   const files: OwnedFile[] = [];
 
   for (const filePath of filePaths) {
-    files.push(await OwnedFile.FromPath(filePath, engine));
+    files.push(await OwnedFile.FromPath(filePath, engine, fileOptions));
   }
 
   return files;

--- a/src/lib/ownership/index.ts
+++ b/src/lib/ownership/index.ts
@@ -1,4 +1,5 @@
 export { OwnedFile } from './lib/OwnedFile';
+export type { FromFileOptions } from './lib/OwnedFile';
 export { OwnershipEngine } from './lib/OwnershipEngine';
 export { getFileOwnership } from './file';
 export { validate } from './validate';

--- a/src/lib/ownership/lib/OwnedFile.ts
+++ b/src/lib/ownership/lib/OwnedFile.ts
@@ -1,6 +1,12 @@
 import { OwnershipEngine } from './OwnershipEngine';
 import * as fs from 'fs';
 import { log } from '../../logger';
+import { OUTPUT_FORMAT } from '../../writers';
+import { needsLineCounts } from '../../writers/types';
+
+export interface FromFileOptions {
+  countLines: boolean;
+}
 
 export class OwnedFile {
   // tslint:disable-next-line:variable-name
@@ -35,12 +41,19 @@ export class OwnedFile {
   }
 
   // tslint:disable-next-line:variable-name
-  public static FromPath = async (filePath: string, engine: OwnershipEngine, opts = { countLines: true }) => {
+  public static FromPath = async (filePath: string, engine: OwnershipEngine, opts: FromFileOptions) => {
     return new OwnedFile({
       path: filePath,
       lines: opts.countLines ? await countLinesInFile(filePath) : 0,
       owners: engine.calcFileOwnership(filePath),
     });
+  }
+
+  // tslint:disable-next-line:variable-name
+  public static RecommendedOptions = (opts: { output: OUTPUT_FORMAT }): FromFileOptions => {
+    return {
+      countLines: needsLineCounts(opts.output),
+    };
   }
 }
 

--- a/src/lib/writers/types.ts
+++ b/src/lib/writers/types.ts
@@ -3,3 +3,13 @@ export enum OUTPUT_FORMAT {
   JSONL = 'jsonl',
   CSV = 'csv',
 }
+
+export function needsLineCounts(format: OUTPUT_FORMAT): boolean {
+  switch (format) {
+    case OUTPUT_FORMAT.SIMPLE: return false;
+    case OUTPUT_FORMAT.CSV: return true;
+    case OUTPUT_FORMAT.JSONL: return true;
+    default:
+      throw new Error(`unreachable: ${format}`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,6 +76,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
   "exclude": [
+    "dist",
     "tests"
   ]
 }


### PR DESCRIPTION
Avoid reading every file every time, which has some performance overhead, but not actually all that much vs. other egregious problems.

There's not really a good way to phrase this, either the command has to be aware of the output mode, the cli has to be aware of the owned file, or the output code has to be async and do the work there. I picked the first.
