### PR TITLE
adding support for multiple files on the who command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,18 +60,18 @@ commander.command('validate')
   });
 
 
-commander.command('who <file>')
-  .description('lists owners of a specific file')
+commander.command('who <files...>')
+  .description('lists owners of a specific file or files')
   .option('-d, --dir <dirPath>', 'path to VCS directory', process.cwd())
   .option('-c, --codeowners <filePath>', 'path to codeowners file (default: "<dir>/.github/CODEOWNERS")')
   .option('-o, --output <outputFormat>', `how to output format eg: ${Object.values(OUTPUT_FORMAT).join(', ')}`, OUTPUT_FORMAT.SIMPLE)
-  .action(async (file, options) => {
+  .action(async (files, options) => {
     try {
-      if (!file) {
+      if (files.length < 1) {
         throw new Error('a file must be defined');
       }
 
-      options.file = file;
+      options.files = files;
 
       if (!options.codeowners) {
         options.codeowners = path.resolve(options.dir, '.github/CODEOWNERS');

--- a/src/commands/__snapshots__/who.test.int.ts.snap
+++ b/src/commands/__snapshots__/who.test.int.ts.snap
@@ -1,8 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`who should list ownership for all files: stderr 1`] = `""`;
+exports[`who should list ownership for multiple files: stderr 1`] = `""`;
 
-exports[`who should list ownership for all files: stdout 1`] = `
+exports[`who should list ownership for multiple files: stdout 1`] = `
+"explicit-ignore.js	@js-owner
+default-wildcard-owners.md	@global-owner1	@global-owner2
+"
+`;
+
+exports[`who should list ownership for one file: stderr 1`] = `""`;
+
+exports[`who should list ownership for one file: stdout 1`] = `
 "default-wildcard-owners.md	@global-owner1	@global-owner2
 "
 `;

--- a/src/commands/who.test.int.ts
+++ b/src/commands/who.test.int.ts
@@ -21,8 +21,14 @@ describe('who', () => {
     return exec(`node  ../../../dist/cli.js ${args}`, { cwd: testDir });
   };
 
-  it('should list ownership for all files', async () => {
+  it('should list ownership for one file', async () => {
     const { stdout, stderr } = await runCli('who default-wildcard-owners.md');
+    expect(stdout).toMatchSnapshot('stdout');
+    expect(stderr).toMatchSnapshot('stderr');
+  });
+
+  it('should list ownership for multiple files', async () => {
+    const { stdout, stderr } = await runCli('who explicit-ignore.js default-wildcard-owners.md');
     expect(stdout).toMatchSnapshot('stdout');
     expect(stderr).toMatchSnapshot('stderr');
   });

--- a/src/commands/who.ts
+++ b/src/commands/who.ts
@@ -2,13 +2,16 @@ import { getOwnership } from '../lib/ownership';
 import { OUTPUT_FORMAT } from '../lib/types';
 
 interface WhoOptions {
-  file: string;
+  files: string[];
   dir: string;
   codeowners: string;
   output: OUTPUT_FORMAT;
 }
 
 export const who = async (options: WhoOptions) => {
-  const [file] = await getOwnership(options.codeowners, [options.file]);
-  file.write(options.output, process.stdout);
+  const files = await getOwnership(options.codeowners, options.files);
+
+  for (const file of files) {
+    file.write(options.output, process.stdout);
+  }
 };


### PR DESCRIPTION
Adds multiple file support on the who command as per https://github.com/jjmschofield/github-codeowners/issues/51

Based on @FauxFaux PR https://github.com/jjmschofield/github-codeowners/pull/43 but re-worked to use the refactored application structure.