### PR TITLE
Exclude non file paths to avoid reading a directory

### DIFF
--- a/src/lib/file/readGit.test.ts
+++ b/src/lib/file/readGit.test.ts
@@ -1,10 +1,24 @@
 import { exec } from '../util/exec';
 import { readGit } from './readGit';
+import fs from 'fs';
 
 jest.mock('../util/exec');
+jest.mock('fs');
+const fsMocked = jest.mocked<any>(fs);
 const execFileMock = exec as jest.Mock;
 
 describe('readGit', () => {
+  beforeEach(() => {
+    fsMocked.statSync.mockImplementation((path: any) => {
+      return {
+        isFile() {
+          if (!path) { return false; }
+          return true;
+        },
+      };
+    });
+  });
+
   it('should return the expected list of files when called', async () => {
     execFileMock.mockResolvedValue({ stdout: 'foo\nbar\n', stderr: '' });
 
@@ -24,5 +38,21 @@ describe('readGit', () => {
         cwd: 'some/dir',
       }),
     );
+  });
+
+  it('should not return non-files', async () => {
+    execFileMock.mockResolvedValue({ stdout: 'foo\nbar\nbaz\n', stderr: '' });
+    fsMocked.statSync.mockImplementation((path: any) => {
+      return {
+        isFile() {
+          if (!path || path === 'baz') { return false; }
+          return true;
+        },
+      };
+    });
+
+    const result = await readGit('some/dir');
+
+    expect(result).toStrictEqual(['foo', 'bar']);
   });
 });

--- a/src/lib/file/readGit.ts
+++ b/src/lib/file/readGit.ts
@@ -1,6 +1,21 @@
+import fs, { Stats } from 'fs';
 import { exec } from '../util/exec';
 
 export const readGit = async (dir: string): Promise<string[]> => {
   const { stdout } = await exec('git ls-files', { cwd: dir });
-  return stdout.split('\n').filter(x => !!x);
+  return stdout.split('\n').filter((filePath) => {
+    let stats: Stats | undefined = undefined;
+    try {
+      stats = fs.statSync(filePath);
+    } catch (e) {
+      return false; // Ignore missing files and symlinks
+    }
+
+    // Ignore if path is not a file
+    if (!stats.isFile()){
+      return false;
+    }
+
+    return true;
+  });
 };


### PR DESCRIPTION
This fixes https://github.com/jjmschofield/github-codeowners/issues/63, when there is a git submodule in the audited repository.
When using `-g`, `git ls-files` return the submodule along side the other files.
There is no filtering in [readGit.ts](https://github.com/jjmschofield/github-codeowners/blob/master/src/lib/file/readGit.ts) like in [readDir.ts#L37](https://github.com/jjmschofield/github-codeowners/blob/master/src/lib/file/readDir.ts#L37)