### PR TITLE
fix: support trailing whitespace

### DIFF
--- a/src/lib/ownership/OwnershipEngine.ts
+++ b/src/lib/ownership/OwnershipEngine.ts
@@ -62,8 +62,8 @@ export class OwnershipEngine {
 }
 
 const createMatcherCodeownersRule = (rule: string): FileOwnershipMatcher => {
-  // Split apart on spaces
-  const parts = rule.split(/\s+/);
+  // Split apart on spaces after removing supported trailing whitespace.
+  const parts = rule.replace(/\s+$/, '').split(/\s+/);
 
   // The first part is expected to be the path
   const path = parts[0];


### PR DESCRIPTION
Thanks for the cool tool! 💯  Discovered that GitHub supports trailing whitespace but this tool doesn't seem to handle it. Errors with `  is not a valid owner name in rule` where `name` is just the trailing whitespace ` `. Updating one line of code to trim trailing whitespace from each rule before parsing. Not sure if leading whitespace is supported by GitHub, so _not_ making that change here too - otherwise I would have used `.trim()`). Could possibly use `. trimEnd()`, but I'm not sure you want to support Node older than v10.0.0 when that was added (see compatibility https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd#browser_compatibility). Thoughts?