### PR TITLE
Extend git ls-files maxBuffer to 3MiB

### DIFF
--- a/src/lib/file/readGit.ts
+++ b/src/lib/file/readGit.ts
@@ -2,7 +2,7 @@ import fs, { Stats } from 'fs';
 import { exec } from '../util/exec';
 
 export const readGit = async (dir: string): Promise<string[]> => {
-  const { stdout } = await exec('git ls-files', { cwd: dir });
+  const { stdout } = await exec('git ls-files', { cwd: dir, maxBuffer: 3 * 2 ** 20, }); // 3MiB
   return stdout.split('\n').filter((filePath) => {
     let stats: Stats | undefined = undefined;
     try {

--- a/src/lib/file/readGit.ts
+++ b/src/lib/file/readGit.ts
@@ -2,7 +2,7 @@ import fs, { Stats } from 'fs';
 import { exec } from '../util/exec';
 
 export const readGit = async (dir: string): Promise<string[]> => {
-  const { stdout } = await exec('git ls-files', { cwd: dir, maxBuffer: 3 * 2 ** 20, }); // 3MiB
+  const { stdout } = await exec('git ls-files', { cwd: dir, maxBuffer: 3 * 2 ** 20 }); // 3MiB
   return stdout.split('\n').filter((filePath) => {
     let stats: Stats | undefined = undefined;
     try {


### PR DESCRIPTION
The `--only-git` is a great feature, but it breaks on larger repositories with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`. [nodejs/node](https://github.com/nodejs/node) is a large public repo that can reproduce the error/fix. Thanks!