### PR TITLE
Ignore trailing whitespace in rules

### DIFF
--- a/src/lib/ownership/OwnershipEngine.test.ts
+++ b/src/lib/ownership/OwnershipEngine.test.ts
@@ -161,7 +161,7 @@ describe('OwnershipEngine', () => {
 
     it('ignore trailing whitespace', () => {
       // Arrange
-      const codeowners = "some/file @org/owners ";
+      const codeowners = 'some/file @org/owners ';
 
       readFileSyncMock.mockReturnValue(Buffer.from(codeowners));
 

--- a/src/lib/ownership/OwnershipEngine.test.ts
+++ b/src/lib/ownership/OwnershipEngine.test.ts
@@ -158,6 +158,17 @@ describe('OwnershipEngine', () => {
       expect(() => OwnershipEngine.FromCodeownersFile('some/codeowners/file'))
         .toThrowError(expectedError);
     });
+
+    it('ignore trailing whitespace', () => {
+      // Arrange
+      const codeowners = "some/file @org/owners ";
+
+      readFileSyncMock.mockReturnValue(Buffer.from(codeowners));
+
+      // Assert
+      expect(() => OwnershipEngine.FromCodeownersFile('some/codeowners/file'))
+        .not.toThrow();
+    });
   });
 
   describe.each<any>(patterns)('$name: "$pattern"', ({ name, pattern, paths }) => {

--- a/src/lib/ownership/OwnershipEngine.ts
+++ b/src/lib/ownership/OwnershipEngine.ts
@@ -63,7 +63,7 @@ export class OwnershipEngine {
 
 const createMatcherCodeownersRule = (rule: string): FileOwnershipMatcher => {
   // Split apart on spaces
-  const parts = rule.split(/\s+/);
+  const parts = rule.split(/\s+/).filter(Boolean);
 
   // The first part is expected to be the path
   const path = parts[0];


### PR DESCRIPTION
There's a small bug in the rule parser that is replicated in the test here. Trailing whitespace is insignificant in Github's implementation.